### PR TITLE
Fixes for 0.15 issues

### DIFF
--- a/crafting_combinator/changelog.txt
+++ b/crafting_combinator/changelog.txt
@@ -1,3 +1,9 @@
+##0.7.1##
+* Fixed wrong icon scale for virtual recipe group
+* Fixed recipes that defined complexities would get a virtual signal even if not necessary ([11640](https://mods.factorio.com/mods/theRustyKnife/crafting_combinator/discussion/11640))
+* Fixed broken localization
+* Enabled sorting virtual recipes into groups
+
 ##0.7.0##
 * Updated for Factorio 0.15
 

--- a/crafting_combinator/config.lua
+++ b/crafting_combinator/config.lua
@@ -27,7 +27,7 @@ config.OVERFLOW_SLOT_COUNT = 1000
 
 
 -- if true, recipes will be sorted into subgroups for better readability (in Factorio 0.14 this causes problems)
-config.USE_RECIPE_SUBGROUPS = false
+config.USE_RECIPE_SUBGROUPS = true
 
 -- recipes matching any of the strings will not get a virtual recipe
 config.RECIPES_TO_IGNORE = {

--- a/crafting_combinator/data-final-fixes.lua
+++ b/crafting_combinator/data-final-fixes.lua
@@ -2,13 +2,21 @@ local FML = require "FML.init"
 local config = require "config"
 
 
-local function is_result(recipe, item)
-	if recipe.result == item then return true; end
-	
-	for _, result in pairs(recipe.results or {}) do
+local function is_result_internal(item, result, results)
+	if item == result then return true; end
+	for _, result in pairs(results or {}) do
 		if result.name == item then return true; end
 	end
-	
+	return false
+end
+local function is_result(recipe, item)
+	if is_result_internal(item, recipe.result, recipe.results) then return true; end
+	if recipe.normal then
+		if is_result_internal(item, recipe.normal.result, recipe.normal.results) then return true; end
+	end
+	if recipe.expensive then
+		return is_result_internal(item, recipe.expensive,result, recipe.expensive.results)
+	end
 	return false
 end
 
@@ -117,7 +125,7 @@ for name, recipe in pairs(data.raw.recipe) do
 			subgroup = data.raw["item-subgroup"]["crafting-combinator-virtual-recipe-subgroup-"..group.name] or FML.data.make_prototype{
 				type = "item-subgroup",
 				name = "crafting-combinator-virtual-recipe-subgroup-"..group.name,
-				group = "signals-crafting-combinator",
+				group = config.GROUP_NAME,
 				order = group.order.."["..group.name.."]",
 			}
 		end

--- a/crafting_combinator/data.lua
+++ b/crafting_combinator/data.lua
@@ -47,12 +47,13 @@ FML.data.make_prototypes{
 		name = config.GROUP_NAME,
 		order = "fb",
 		icon = "__crafting_combinator__/graphics/recipe-book.png",
+		icon_size = 64,
 	},
 	{
 		type = "item-subgroup",
 		name = "crafting_combinator-signals",
-		group = "signals", --TODO: change this to be in our group once 0.15 comes out
-		order = "zzz",
+		group = config.GROUP_NAME,
+		order = "___",
 	},
 	{
 		type = "item-subgroup",

--- a/crafting_combinator/info.json
+++ b/crafting_combinator/info.json
@@ -1,11 +1,11 @@
 {
 	"name": "crafting_combinator",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"factorio_version": "0.15",
 	"title": "Crafting Combinator",
 	"author": "LuziferSenpai and theRustyKnife",
 	"description": "Includes combinators that allow you to set or read the recipe of any crafting machine, get ingredients or products of a recipe and more!",
 	"homepage": "https://mods.factorio.com/mods/theRustyKnife/crafting_combinator",
-	"date": "24.04.2017",
+	"date": "08.05.2017",
 	"dependencies": ["base", "?ZRecycling"]
 }

--- a/crafting_combinator/locale/cs/cs.cfg
+++ b/crafting_combinator/locale/cs/cs.cfg
@@ -23,7 +23,7 @@ crafting_combinator_gui_title_cc-refresh-rate=Výrobní kombinátor:
 crafting_combinator_gui_title_rc-refresh-rate=Receptový kombinátor: 
 
 [crafting-combinator]
-locale = Recept __1__
+locale=Recept __1__
 
 [entity-description]
 crafting_combinator_crafting-combinator=Nastavuje, nebo čte recept výrobny

--- a/crafting_combinator/locale/en/en.cfg
+++ b/crafting_combinator/locale/en/en.cfg
@@ -24,7 +24,7 @@ crafting_combinator_gui_title_cc-refresh-rate=Crafting combinator:
 crafting_combinator_gui_title_rc-refresh-rate=Recipe combinator: 
 
 [crafting-combinator]
-locale = Recipe __1__
+locale=Recipe __1__
 
 [entity-description]
 crafting_combinator_crafting-combinator=Sets or reads the recipe of an assembler


### PR DESCRIPTION
* Fixed wrong icon scale for virtual recipe group
* Fixed recipes that defined complexities would get a virtual signal
even if not necessary
([11640](https://mods.factorio.com/mods/theRustyKnife/crafting_combinator/discussion/11640))
* Fixed broken localization
* Enabled sorting virtual recipes into groups